### PR TITLE
fix: improve Twitter markdown conversion and Reddit block detection

### DIFF
--- a/src/lib/scrape/validate-html-content.ts
+++ b/src/lib/scrape/validate-html-content.ts
@@ -13,6 +13,7 @@ const BLOCK_PATTERNS: RegExp[] = [
   // Security blocks
   /To help us keep this website secure/i,
   /You've been blocked/i,
+  /been blocked by network security/i,
   /Access denied/i,
   /403 Forbidden/i,
   /Request blocked/i,


### PR DESCRIPTION
## Summary
- Bypass Defuddle for Twitter/X URLs — fetch structured data via APIs and convert directly to Markdown
- Add new `twitter-to-markdown.ts` module for rich tweet-to-Markdown conversion (articles, media, engagement stats, replies)
- Detect Reddit "been blocked by network security" in HTML validation to trigger fallback chain

## Changes
- `src/lib/scrape/get-twitter-content.ts`: Add `getTwitterContent()` export for structured tweet data
- `src/lib/scrape/twitter-to-markdown.ts`: New module — converts Twitter API data to formatted Markdown
- `src/modules/convert/convert-crud.ts`: Add Twitter URL detection → direct Markdown conversion before Defuddle
- `src/lib/scrape/validate-html-content.ts`: Add block pattern for Reddit's network security page

## Test plan
- [ ] Convert a Twitter/X URL to markdown — should use twitter-api model, not Defuddle/LLM
- [ ] Convert a Reddit URL that returns block page — should fallback to next scraping method
- [ ] Convert a non-Twitter URL — should still use Defuddle → LLM flow unchanged

Closes #25