### PR TITLE
style: apply linter formatting to Twitter conversion modules

### DIFF
--- a/src/lib/scrape/get-twitter-content.ts
+++ b/src/lib/scrape/get-twitter-content.ts
@@ -170,8 +170,7 @@ async function fetchWithFxTwitter(tweetId: string, debug?: boolean): Promise<Twi
     }
 
     const coverUrl =
-      tweet.article.cover_media?.media_info?.original_img_url ||
-      tweet.article.cover_media?.url;
+      tweet.article.cover_media?.media_info?.original_img_url || tweet.article.cover_media?.url;
 
     article = {
       title: tweet.article.title || "",

--- a/src/lib/scrape/twitter-to-markdown.ts
+++ b/src/lib/scrape/twitter-to-markdown.ts
@@ -266,9 +266,7 @@ function resolveArticleMediaUrl(
   mediaId: string,
   mediaEntities: any[]
 ): { url: string; type: "image" | "video" } | null {
-  const entity = mediaEntities.find(
-    (m: any) => m.media_id === mediaId || m.media_key === mediaId
-  );
+  const entity = mediaEntities.find((m: any) => m.media_id === mediaId || m.media_key === mediaId);
   if (!entity) return null;
 
   const info = entity.media_info;

--- a/src/modules/convert/convert-crud.ts
+++ b/src/modules/convert/convert-crud.ts
@@ -23,7 +23,8 @@ export async function convertUrlToMarkdown(url: string, options?: ConvertWebUrlO
 
   // Step 2: Twitter/X URLs — bypass Defuddle, convert structured data directly to Markdown
   if (isTwitterUrl(url)) {
-    if (debug) console.log(`convert-crud.ts > Detected Twitter URL, using direct Markdown conversion`);
+    if (debug)
+      console.log(`convert-crud.ts > Detected Twitter URL, using direct Markdown conversion`);
     try {
       const twitterContent = await getTwitterContent(url, {
         debug,


### PR DESCRIPTION
## Summary
- Apply linter auto-formatting (line wrapping) to Twitter conversion modules
- No logic changes — cosmetic only

## Files
- `src/lib/scrape/get-twitter-content.ts` — line wrap
- `src/lib/scrape/twitter-to-markdown.ts` — line wrap
- `src/modules/convert/convert-crud.ts` — line wrap
- `src/lib/scrape/validate-html-content.ts` — Reddit block pattern (from merged PR #26)

## Test plan
- [x] No logic changes, linter-only formatting