### PR TITLE
fix: initialize Redis on server startup and add in-memory rate limit fallback

### DIFF
--- a/src/lib/utils/extract-zip-to-temp-dir.ts
+++ b/src/lib/utils/extract-zip-to-temp-dir.ts
@@ -56,7 +56,10 @@ export async function extractZipToTempDir(
     // Zip-slip protection: validate all entry paths before extraction
     const targetPath = path.join(extractDir, entry.entryName);
     const resolvedPath = path.resolve(targetPath);
-    if (!resolvedPath.startsWith(resolvedExtractDir + path.sep) && resolvedPath !== resolvedExtractDir) {
+    if (
+      !resolvedPath.startsWith(resolvedExtractDir + path.sep) &&
+      resolvedPath !== resolvedExtractDir
+    ) {
       fs.rmSync(extractDir, { recursive: true, force: true });
       throw new Error(`Zip-slip detected: ${entry.entryName}`);
     }

--- a/src/middlewares/check-plan-limits.ts
+++ b/src/middlewares/check-plan-limits.ts
@@ -22,6 +22,52 @@ const getRedisKeys = (userId: string) => {
   return { minuteKey, monthKey };
 };
 
+// --- In-memory fallback when Redis is unavailable ---
+const memCache = new Map<string, { count: number; expiresAt: number }>();
+
+function memIncr(key: string, ttlSeconds: number): number {
+  const now = Date.now();
+  const entry = memCache.get(key);
+
+  if (entry && entry.expiresAt > now) {
+    entry.count += 1;
+    return entry.count;
+  }
+
+  // Expired or new — reset
+  memCache.set(key, { count: 1, expiresAt: now + ttlSeconds * 1000 });
+  return 1;
+}
+
+// Periodically clean up expired entries (every 5 minutes)
+// .unref() allows Node to exit cleanly without waiting for this timer
+setInterval(
+  () => {
+    const now = Date.now();
+    for (const [key, entry] of memCache) {
+      if (entry.expiresAt <= now) memCache.delete(key);
+    }
+  },
+  5 * 60 * 1000
+).unref();
+
+/**
+ * Increment a rate-limit counter using Redis, falling back to in-memory Map.
+ */
+async function incrCounter(key: string, ttlSeconds: number): Promise<number> {
+  // Redis unavailable — use in-memory fallback
+  if (!redis) return memIncr(key, ttlSeconds);
+
+  try {
+    const count = await redis.incr(key);
+    await redis.expire(key, ttlSeconds);
+    return count;
+  } catch {
+    // Redis error at runtime — fallback to memory
+    return memIncr(key, ttlSeconds);
+  }
+}
+
 /**
  * Middleware to check user plan request limits
  */
@@ -48,10 +94,7 @@ export const checkPlanLimits = async (_req: Request, res: Response, next: NextFu
     // Check requests per minute (sliding window)
     const currentMinute = dayjs().minute();
     const minuteWindow = `${minuteKey}:${currentMinute}`;
-    const requestsThisMinute = await redis.incr(minuteWindow);
-
-    // Set expiry for minute window (1 minute)
-    await redis.expire(minuteWindow, 60);
+    const requestsThisMinute = await incrCounter(minuteWindow, 60);
 
     if (requestsThisMinute > maxRequestsPerMinute) {
       return res
@@ -60,12 +103,9 @@ export const checkPlanLimits = async (_req: Request, res: Response, next: NextFu
     }
 
     // Check requests per month
-    const currentMonth = dayjs().format("YYYY-MM"); // YYYY-MM
+    const currentMonth = dayjs().format("YYYY-MM");
     const monthWindow = `${monthKey}:${currentMonth}`;
-    const requestsThisMonth = await redis.incr(monthWindow);
-
-    // Set expiry for month window (31 days to be safe)
-    await redis.expire(monthWindow, 31 * 24 * 60 * 60);
+    const requestsThisMonth = await incrCounter(monthWindow, 31 * 24 * 60 * 60);
 
     if (requestsThisMonth > maxRequestsPerMonth) {
       return res

--- a/src/routes/api/api-html-to-screenshot.ts
+++ b/src/routes/api/api-html-to-screenshot.ts
@@ -58,12 +58,7 @@ function sanitizeEntryFile(entryFile: string): string {
 }
 
 /** Send output as R2 URL or direct image buffer */
-async function sendOutput(
-  res: express.Response,
-  buffer: Buffer,
-  output: string,
-  type: string
-) {
+async function sendOutput(res: express.Response, buffer: Buffer, output: string, type: string) {
   if (output === "buffer") {
     res.set("Content-Type", type === "jpeg" ? "image/jpeg" : "image/png");
     return res.send(buffer);
@@ -253,7 +248,7 @@ apiHtmlToScreenshotRouter.post(
           } catch {
             return res.status(400).json({
               success: false,
-              message: "Invalid viewport JSON. Expected: {\"width\": number, \"height\": number}",
+              message: 'Invalid viewport JSON. Expected: {"width": number, "height": number}',
             });
           }
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { pageRouter } from "@/routes/pages";
 
 import { swaggerOptions } from "./config";
 import { fetchListAIModels } from "./lib/ai/models";
+import { initRedis } from "./lib/redis";
 import { createInitialCategories } from "./modules/category";
 import { polarWebhookRouter } from "./routes/webhooks/polar-webhook";
 
@@ -145,6 +146,7 @@ app.use((error: any, _req: express.Request, res: express.Response, _next: expres
 
 // start server
 async function startServer() {
+  initRedis();
   await createInitialPlans();
   await initWorkspacePermissions();
   await browserPool.initialize();


### PR DESCRIPTION
## Summary
- **Root cause**: `initRedis()` was never called during server startup, leaving the Redis client `undefined`
- `checkPlanLimits` middleware crashed with `TypeError: Cannot read properties of undefined (reading 'incr')` on every html-to-screenshot API request
- Added `initRedis()` call in `startServer()` and in-memory `Map` fallback for rate limiting when Redis is unavailable

## Changes
- `src/server.ts`: Import and call `initRedis()` during startup
- `src/middlewares/check-plan-limits.ts`: Add `incrCounter()` helper with Redis-first + memcache fallback pattern, periodic cleanup with `.unref()` for graceful shutdown

## Test plan
- [ ] Deploy and verify html-to-screenshot API returns 201 with screenshot URL
- [ ] Verify no 500 errors in checkPlanLimits middleware logs
- [ ] Confirm Redis connects successfully on startup (look for "Redis: Connected" log)
- [ ] Test rate limiting still works (hit limit → 429 response)