### PR TITLE
feat: LinkedIn profile & company scraper with dual-provider fallback

### DIFF
--- a/src/lib/scrape/get-html-with-fallbacks.ts
+++ b/src/lib/scrape/get-html-with-fallbacks.ts
@@ -7,6 +7,7 @@ import { wait } from "@/lib/utils/wait";
 import { extractContentWithDefuddle } from "./extract-content-with-defuddle";
 import { getFacebookHtml, isFacebookUrl } from "./get-facebook-content";
 import { getHtmlWithAxios } from "./get-html-with-axios";
+import { getLinkedInHtml, isLinkedInUrl } from "./get-linkedin-content";
 import { getHtmlWithFirecrawl } from "./get-html-with-firecrawl";
 import { getHtmlContent } from "./get-html-with-playwright";
 import { getHtmlWithScrapedo } from "./get-html-with-scrapedo";
@@ -271,6 +272,23 @@ export async function getHtmlWithFallbacks(url: string, options?: ScrapeOptions)
       if (debug)
         console.log(
           `get-html-with-fallbacks.ts > Facebook handler failed: ${errorMsg}, falling back to generic methods`
+        );
+    }
+  }
+
+  // Special handling for LinkedIn URLs - use specialized LinkedIn fetcher first
+  if (isLinkedInUrl(url)) {
+    if (debug)
+      console.log(`get-html-with-fallbacks.ts > Detected LinkedIn URL, using specialized handler`);
+    try {
+      const html = await getLinkedInHtml(url, { debug, timeout: opts.timeout });
+      if (debug) console.log(`get-html-with-fallbacks.ts > Successfully fetched LinkedIn content`);
+      return opts.simpleHtml ? await extractOrSimplifyHtml(html, url) : html;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      if (debug)
+        console.log(
+          `get-html-with-fallbacks.ts > LinkedIn handler failed: ${errorMsg}, falling back to generic methods`
         );
     }
   }

--- a/src/lib/scrape/get-linkedin-content.ts
+++ b/src/lib/scrape/get-linkedin-content.ts
@@ -1,0 +1,206 @@
+/**
+ * LinkedIn Content Fetcher
+ * Specialized module for fetching content from LinkedIn profile & company URLs.
+ * Uses 2 chained RapidAPI providers with fallback:
+ *   1. Fresh LinkedIn Scraper API (SaleLeads) — takes username/slug
+ *   2. Fresh LinkedIn Profile Data (FreshData) — takes full linkedin_url
+ *
+ * Providers: ./linkedin-api-providers.ts
+ * HTML templates: ./linkedin-html-templates.ts
+ */
+
+import { env } from "@/env";
+
+import {
+	provider1GetCompany,
+	provider1GetProfile,
+	provider2GetCompany,
+	provider2GetProfile,
+} from "./linkedin-api-providers";
+import { companyToHtml, profileToHtml } from "./linkedin-html-templates";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LinkedInProfile {
+	name: string;
+	headline?: string;
+	location?: string;
+	summary?: string;
+	avatar?: string;
+	cover?: string;
+	publicIdentifier?: string;
+	followers?: number;
+	connections?: number;
+	isOpenToWork?: boolean;
+	isPremium?: boolean;
+}
+
+export interface LinkedInCompany {
+	name: string;
+	description?: string;
+	industry?: string;
+	website?: string;
+	logo?: string;
+	cover?: string;
+	employeeCount?: number;
+	headquarters?: string;
+	founded?: number;
+	specialties?: string[];
+}
+
+export interface LinkedInContent {
+	type: "profile" | "company";
+	profile?: LinkedInProfile;
+	company?: LinkedInCompany;
+	html: string;
+}
+
+export interface LinkedInFetchOptions {
+	debug?: boolean;
+	timeout?: number;
+}
+
+// ---------------------------------------------------------------------------
+// URL Detection
+// ---------------------------------------------------------------------------
+
+/** Check if URL is any LinkedIn URL */
+export function isLinkedInUrl(url: string): boolean {
+	try {
+		const host = new URL(url).hostname.toLowerCase();
+		return host === "linkedin.com" || host.endsWith(".linkedin.com");
+	} catch {
+		return false;
+	}
+}
+
+/** Check if URL is a LinkedIn personal profile */
+export function isLinkedInProfileUrl(url: string): boolean {
+	if (!isLinkedInUrl(url)) return false;
+	return /\/in\/[^/]+/i.test(new URL(url).pathname);
+}
+
+/** Check if URL is a LinkedIn company page */
+export function isLinkedInCompanyUrl(url: string): boolean {
+	if (!isLinkedInUrl(url)) return false;
+	return /\/company\/[^/]+/i.test(new URL(url).pathname);
+}
+
+/** Extract username slug from profile URL (e.g. "williamhgates") */
+export function extractLinkedInUsername(url: string): string | null {
+	try {
+		const match = new URL(url).pathname.match(/\/in\/([^/?#]+)/i);
+		return match?.[1] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** Extract company slug from company URL (e.g. "microsoft") */
+export function extractLinkedInCompanySlug(url: string): string | null {
+	try {
+		const match = new URL(url).pathname.match(/\/company\/([^/?#]+)/i);
+		return match?.[1] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch LinkedIn content (profile or company) using chained providers.
+ * Provider 1 (SaleLeads) is tried first; on failure, falls back to Provider 2 (FreshData).
+ */
+export async function getLinkedInContent(
+	url: string,
+	options?: LinkedInFetchOptions
+): Promise<LinkedInContent> {
+	const opts: LinkedInFetchOptions = { timeout: 15000, ...options };
+	const debug = opts.debug ?? false;
+
+	if (!env.RAPID_API_KEY) {
+		throw new Error("RAPID_API_KEY not configured");
+	}
+
+	const isProfile = isLinkedInProfileUrl(url);
+	const isCompany = isLinkedInCompanyUrl(url);
+
+	if (!isProfile && !isCompany) {
+		throw new Error(`Unsupported LinkedIn URL type: ${url}`);
+	}
+
+	// Normalise URL for Provider 2 (needs full URL with trailing slash)
+	const normalizedUrl = url.endsWith("/") ? url : `${url}/`;
+	const errors: string[] = [];
+
+	if (isProfile) {
+		const username = extractLinkedInUsername(url);
+
+		// Provider 1
+		if (username) {
+			try {
+				const profile = await provider1GetProfile(username, opts);
+				return { type: "profile", profile, html: profileToHtml(profile, url) };
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				if (debug) console.log(`get-linkedin-content.ts > Provider1 failed: ${msg}`);
+				errors.push(`Provider1: ${msg}`);
+			}
+		}
+
+		// Provider 2 (fallback)
+		try {
+			const profile = await provider2GetProfile(normalizedUrl, opts);
+			return { type: "profile", profile, html: profileToHtml(profile, url) };
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (debug) console.log(`get-linkedin-content.ts > Provider2 failed: ${msg}`);
+			errors.push(`Provider2: ${msg}`);
+		}
+	}
+
+	if (isCompany) {
+		const slug = extractLinkedInCompanySlug(url);
+
+		// Provider 1
+		if (slug) {
+			try {
+				const company = await provider1GetCompany(slug, opts);
+				return { type: "company", company, html: companyToHtml(company, url) };
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				if (debug) console.log(`get-linkedin-content.ts > Provider1 failed: ${msg}`);
+				errors.push(`Provider1: ${msg}`);
+			}
+		}
+
+		// Provider 2 (fallback)
+		try {
+			const company = await provider2GetCompany(normalizedUrl, opts);
+			return { type: "company", company, html: companyToHtml(company, url) };
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (debug) console.log(`get-linkedin-content.ts > Provider2 failed: ${msg}`);
+			errors.push(`Provider2: ${msg}`);
+		}
+	}
+
+	throw new Error(`All LinkedIn providers failed for ${url}`);
+}
+
+/**
+ * Fetch LinkedIn content and return HTML string.
+ * Drop-in compatible with getTwitterHtml / getFacebookHtml pattern.
+ */
+export async function getLinkedInHtml(
+	url: string,
+	options?: LinkedInFetchOptions
+): Promise<string> {
+	const content = await getLinkedInContent(url, options);
+	return content.html;
+}

--- a/src/lib/scrape/index.ts
+++ b/src/lib/scrape/index.ts
@@ -1,6 +1,7 @@
 export * from "./extract-content-with-defuddle";
 export * from "./get-facebook-content";
 export * from "./get-html-with-axios";
+export * from "./get-linkedin-content";
 export * from "./get-html-with-fallbacks";
 export * from "./get-html-with-firecrawl";
 export * from "./get-html-with-playwright";

--- a/src/lib/scrape/linkedin-api-providers.ts
+++ b/src/lib/scrape/linkedin-api-providers.ts
@@ -1,0 +1,169 @@
+/**
+ * LinkedIn RapidAPI Provider Implementations
+ * Provider 1: Fresh LinkedIn Scraper API (SaleLeads)
+ * Provider 2: Fresh LinkedIn Profile Data (FreshData)
+ */
+
+import axios from "axios";
+
+import { env } from "@/env";
+
+import type { LinkedInCompany, LinkedInFetchOptions, LinkedInProfile } from "./get-linkedin-content";
+
+// ---------------------------------------------------------------------------
+// Provider 1 — Fresh LinkedIn Scraper API (SaleLeads)
+// ---------------------------------------------------------------------------
+
+const PROVIDER1_HOST = "fresh-linkedin-scraper-api.p.rapidapi.com";
+
+function provider1Headers() {
+	return {
+		"x-rapidapi-key": env.RAPID_API_KEY,
+		"x-rapidapi-host": PROVIDER1_HOST,
+	};
+}
+
+export async function provider1GetProfile(
+	username: string,
+	options: LinkedInFetchOptions
+): Promise<LinkedInProfile> {
+	const { debug, timeout = 15000 } = options;
+	if (debug) console.log(`linkedin-api-providers.ts > Provider1 profile: ${username}`);
+
+	const { data } = await axios.get(`https://${PROVIDER1_HOST}/api/v1/user/profile`, {
+		params: { username },
+		headers: provider1Headers(),
+		timeout,
+	});
+
+	if (!data?.success || !data?.data) {
+		throw new Error(`Provider1 profile: ${data?.message || "no data returned"}`);
+	}
+
+	const d = data.data;
+	return {
+		name: d.full_name || `${d.first_name || ""} ${d.last_name || ""}`.trim(),
+		headline: d.headline,
+		location: [d.location?.city, d.location?.country].filter(Boolean).join(", ") || undefined,
+		summary: d.summary,
+		avatar: d.profile_image_url || d.avatar,
+		cover: d.cover?.[0]?.url,
+		publicIdentifier: d.public_identifier,
+		followers: d.follower_count,
+		connections: d.connection_count,
+		isOpenToWork: d.is_open_to_work,
+		isPremium: d.is_premium,
+	};
+}
+
+export async function provider1GetCompany(
+	companySlug: string,
+	options: LinkedInFetchOptions
+): Promise<LinkedInCompany> {
+	const { debug, timeout = 15000 } = options;
+	if (debug) console.log(`linkedin-api-providers.ts > Provider1 company: ${companySlug}`);
+
+	const { data } = await axios.get(`https://${PROVIDER1_HOST}/api/v1/company/profile`, {
+		params: { company: companySlug },
+		headers: provider1Headers(),
+		timeout,
+	});
+
+	if (!data?.success || !data?.data) {
+		throw new Error(`Provider1 company: ${data?.message || "no data returned"}`);
+	}
+
+	const d = data.data;
+	return {
+		name: d.name,
+		description: d.description,
+		industry: d.industry,
+		website: d.website,
+		logo: d.logo,
+		cover: d.cover_image,
+		employeeCount: d.employee_count ?? d.staff_count,
+		headquarters: d.headquarters,
+		founded: d.founded_year ?? d.founded,
+		specialties: d.specialities ?? d.specialties,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Provider 2 — Fresh LinkedIn Profile Data (FreshData)
+// ---------------------------------------------------------------------------
+
+const PROVIDER2_HOST = "fresh-linkedin-profile-data.p.rapidapi.com";
+
+function provider2Headers() {
+	return {
+		"x-rapidapi-key": env.RAPID_API_KEY,
+		"x-rapidapi-host": PROVIDER2_HOST,
+	};
+}
+
+export async function provider2GetProfile(
+	linkedinUrl: string,
+	options: LinkedInFetchOptions
+): Promise<LinkedInProfile> {
+	const { debug, timeout = 15000 } = options;
+	if (debug) console.log(`linkedin-api-providers.ts > Provider2 profile: ${linkedinUrl}`);
+
+	const { data } = await axios.get(`https://${PROVIDER2_HOST}/enrich-lead`, {
+		params: { linkedin_url: linkedinUrl },
+		headers: provider2Headers(),
+		timeout,
+	});
+
+	if (!data?.data) {
+		throw new Error(`Provider2 profile: no data returned`);
+	}
+
+	const d = data.data;
+	return {
+		name: d.full_name || `${d.first_name || ""} ${d.last_name || ""}`.trim(),
+		headline: d.headline || d.occupation,
+		location: d.location || d.city,
+		summary: d.summary || d.about,
+		avatar: d.profile_image_url || d.profile_pic_url,
+		cover: d.background_cover_image_url,
+		publicIdentifier: d.public_identifier || d.linkedin_id,
+		followers: d.follower_count,
+		connections: d.connections_count ?? d.connections,
+		isOpenToWork: d.is_open_to_work,
+		isPremium: d.is_premium,
+	};
+}
+
+export async function provider2GetCompany(
+	linkedinUrl: string,
+	options: LinkedInFetchOptions
+): Promise<LinkedInCompany> {
+	const { debug, timeout = 15000 } = options;
+	if (debug) console.log(`linkedin-api-providers.ts > Provider2 company: ${linkedinUrl}`);
+
+	const { data } = await axios.get(`https://${PROVIDER2_HOST}/get-company-by-linkedinurl`, {
+		params: { linkedin_url: linkedinUrl },
+		headers: provider2Headers(),
+		timeout,
+	});
+
+	if (!data?.data) {
+		throw new Error(`Provider2 company: no data returned`);
+	}
+
+	const d = data.data;
+	return {
+		name: d.name || d.company_name,
+		description: d.description,
+		industry: d.industry,
+		website: d.website,
+		logo: d.logo || d.profile_pic_url,
+		cover: d.background_cover_image_url || d.cover_image_url,
+		employeeCount: d.company_size ?? d.staff_count ?? d.employee_count,
+		headquarters: d.hq?.city
+			? [d.hq.city, d.hq.state, d.hq.country].filter(Boolean).join(", ")
+			: d.headquarters,
+		founded: d.founded_year ?? d.founded,
+		specialties: d.specialities ?? d.specialties,
+	};
+}

--- a/src/lib/scrape/linkedin-html-templates.ts
+++ b/src/lib/scrape/linkedin-html-templates.ts
@@ -1,0 +1,105 @@
+/**
+ * LinkedIn HTML Template Generation
+ * Converts LinkedIn profile/company data into structured HTML.
+ * All user-supplied values are escaped to prevent XSS.
+ */
+
+import type { LinkedInCompany, LinkedInProfile } from "./get-linkedin-content";
+
+// ---------------------------------------------------------------------------
+// HTML Escaping
+// ---------------------------------------------------------------------------
+
+const ESCAPE_MAP: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#39;",
+};
+
+/** Escape HTML special characters to prevent XSS */
+function esc(value: string | number | undefined | null): string {
+	if (value == null) return "";
+	return String(value).replace(/[&<>"']/g, (ch) => ESCAPE_MAP[ch] || ch);
+}
+
+/** Validate URL starts with https: for safe use in href/src attributes */
+function safeUrl(url: string | undefined | null): string {
+	if (!url) return "";
+	const trimmed = url.trim();
+	if (trimmed.startsWith("https://") || trimmed.startsWith("http://")) return trimmed;
+	return "";
+}
+
+// ---------------------------------------------------------------------------
+// Profile HTML
+// ---------------------------------------------------------------------------
+
+export function profileToHtml(profile: LinkedInProfile, url: string): string {
+	const escapedUrl = esc(url);
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LinkedIn Profile — ${esc(profile.name)}</title>
+</head>
+<body>
+  <article class="linkedin-profile">
+    <header>
+      ${safeUrl(profile.cover) ? `<img src="${safeUrl(profile.cover)}" alt="Cover" class="cover" />` : ""}
+      ${safeUrl(profile.avatar) ? `<img src="${safeUrl(profile.avatar)}" alt="${esc(profile.name)}" class="avatar" />` : ""}
+      <h1>${esc(profile.name)}</h1>
+      ${profile.headline ? `<p class="headline">${esc(profile.headline)}</p>` : ""}
+      ${profile.location ? `<p class="location">${esc(profile.location)}</p>` : ""}
+    </header>
+    ${profile.summary ? `<section class="summary"><p>${esc(profile.summary)}</p></section>` : ""}
+    <footer>
+      ${profile.followers != null ? `<span class="followers">${esc(profile.followers.toLocaleString())} followers</span>` : ""}
+      ${profile.connections != null ? `<span class="connections">${esc(profile.connections.toLocaleString())} connections</span>` : ""}
+      ${profile.isOpenToWork ? `<span class="badge">Open to work</span>` : ""}
+      ${profile.isPremium ? `<span class="badge">Premium</span>` : ""}
+      <a href="${escapedUrl}" target="_blank" rel="noopener">View on LinkedIn</a>
+    </footer>
+  </article>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Company HTML
+// ---------------------------------------------------------------------------
+
+export function companyToHtml(company: LinkedInCompany, url: string): string {
+	const escapedUrl = esc(url);
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LinkedIn Company — ${esc(company.name)}</title>
+</head>
+<body>
+  <article class="linkedin-company">
+    <header>
+      ${safeUrl(company.cover) ? `<img src="${safeUrl(company.cover)}" alt="Cover" class="cover" />` : ""}
+      ${safeUrl(company.logo) ? `<img src="${safeUrl(company.logo)}" alt="${esc(company.name)}" class="logo" />` : ""}
+      <h1>${esc(company.name)}</h1>
+      ${company.industry ? `<p class="industry">${esc(company.industry)}</p>` : ""}
+    </header>
+    ${company.description ? `<section class="description"><p>${esc(company.description)}</p></section>` : ""}
+    <ul class="details">
+      ${safeUrl(company.website) ? `<li><strong>Website:</strong> <a href="${safeUrl(company.website)}" target="_blank" rel="noopener">${esc(company.website)}</a></li>` : ""}
+      ${company.headquarters ? `<li><strong>Headquarters:</strong> ${esc(company.headquarters)}</li>` : ""}
+      ${company.employeeCount ? `<li><strong>Employees:</strong> ${esc(company.employeeCount.toLocaleString())}</li>` : ""}
+      ${company.founded ? `<li><strong>Founded:</strong> ${esc(company.founded)}</li>` : ""}
+      ${company.specialties?.length ? `<li><strong>Specialties:</strong> ${esc(company.specialties.join(", "))}</li>` : ""}
+    </ul>
+    <footer>
+      <a href="${escapedUrl}" target="_blank" rel="noopener">View on LinkedIn</a>
+    </footer>
+  </article>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- Detect LinkedIn URLs (`/in/{user}` profiles, `/company/{slug}` pages) and scrape structured data via RapidAPI
- Chain 2 providers with automatic fallback: Fresh LinkedIn Scraper API (SaleLeads) → Fresh LinkedIn Profile Data (FreshData)
- XSS-safe HTML output with escaped user-supplied values
- Integrates into existing `getHtmlWithFallbacks()` alongside Twitter/Facebook handlers

## Files Changed
| File | Change |
|------|--------|
| `src/lib/scrape/get-linkedin-content.ts` | **New** — Types, URL detection, orchestrator |
| `src/lib/scrape/linkedin-api-providers.ts` | **New** — Provider 1 & 2 API implementations |
| `src/lib/scrape/linkedin-html-templates.ts` | **New** — HTML generation with XSS escaping |
| `src/lib/scrape/get-html-with-fallbacks.ts` | Add LinkedIn detection block |
| `src/lib/scrape/index.ts` | Export new module |

## Provider Details
| Provider | Host | Profile Endpoint | Company Endpoint |
|----------|------|-----------------|------------------|
| SaleLeads | `fresh-linkedin-scraper-api.p.rapidapi.com` | `GET /api/v1/user/profile?username=` | `GET /api/v1/company/profile?company=` |
| FreshData | `fresh-linkedin-profile-data.p.rapidapi.com` | `GET /enrich-lead?linkedin_url=` | `GET /get-company-by-linkedinurl?linkedin_url=` |

## Test plan
- [ ] Verify LinkedIn profile URL detection (`https://linkedin.com/in/williamhgates`)
- [ ] Verify LinkedIn company URL detection (`https://linkedin.com/company/microsoft`)
- [ ] Test Provider 1 → Provider 2 fallback chain
- [ ] Confirm non-LinkedIn URLs still route to generic scrapers
- [ ] Verify HTML output is XSS-safe (no raw interpolation)